### PR TITLE
Resolve failures across old WEO publications

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: imfweo
 Title: Seamless Access to IMF World Economic Outlook (WEO) Data
-Version: 0.1.0.9000
+Version: 0.1.0.9001
 Authors@R: 
     c(person("Teal", "Emery", , "lte@tealinsights.com", role = c("aut", "cre")),
       person("Teal Insights", role = c("cph")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # imfweo (development version)
 
+* Add support for all publications until 2025 Spring. 
+
 # imfweo 0.1.0
 
 * Initial CRAN submission with `weo_get()`, `weo_get_series()`, `weo_entities()`, `weo_latest_publication()`, `weo_list_publications()`

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # imfweo (development version)
 
-* Add support for all publications until 2025 Spring. 
+## Bug fixes
+
+* Add support for all publications until 2025 Spring in `weo_get()`. 
 
 # imfweo 0.1.0
 

--- a/R/weo_bulk.R
+++ b/R/weo_bulk.R
@@ -156,6 +156,9 @@ create_weo_url <- function(year, release, country_groups = FALSE) {
   } else if (year >= 2021) {
     # Format from April 2021 to 2023
     paste0(base_url, "/", year, "/WEO", month, year, suffix, ".ashx")
+  } else if (year == 2020 && release == 1) {
+    # Special case: April 2020 uses .ashx
+    paste0(base_url, "/", year, "/WEO", month, year, suffix, ".ashx")
   } else if (year >= 2020) {
     # Format from October 2020
     release_pad <- ifelse(
@@ -234,58 +237,6 @@ read_weo_file <- function(file_path) {
 #' @noRd
 check_file <- function(file_path) {
   !file.exists(file_path) || file.size(file_path) == 0
-}
-
-#' Create WEO Download URL
-#'
-#' @keywords internal
-#' @noRd
-create_weo_url <- function(year, release, country_groups = FALSE) {
-  base_url <- "https://www.imf.org/-/media/Files/Publications/WEO/WEO-Database"
-  month <- ifelse(release == 1, "Apr", "Oct")
-  month_long <- ifelse(release == 1, "April", "October")
-  suffix <- ifelse(country_groups, "alla", "all")
-
-  # New format since April 2024
-  if (year >= 2024) {
-    paste0(
-      base_url,
-      "/",
-      year,
-      "/",
-      month_long,
-      "/WEO",
-      month,
-      year,
-      suffix,
-      ".xls"
-    )
-  } else if (year >= 2021) {
-    # Format from April 2021 to 2023
-    paste0(base_url, "/", year, "/WEO", month, year, suffix, ".ashx")
-  } else if (year >= 2020) {
-    # Format from October 2020
-    release_pad <- ifelse(
-      release < 10,
-      paste0("0", release),
-      as.character(release)
-    )
-    paste0(
-      base_url,
-      "/",
-      year,
-      "/",
-      release_pad,
-      "/WEO",
-      month,
-      year,
-      suffix,
-      ".xls"
-    )
-  } else {
-    # Earlier format
-    paste0(base_url, "/", year, "/WEO", month, year, suffix, ".xls")
-  }
 }
 
 #' Read WEO File

--- a/R/weo_bulk.R
+++ b/R/weo_bulk.R
@@ -329,7 +329,8 @@ process_weo_data <- function(raw_data) {
     tidyr::pivot_longer(
       cols = dplyr::all_of(year_cols),
       names_to = "year",
-      values_to = "value"
+      values_to = "value",
+      values_transform = list(value = as.character)
     )
 
   clean_values <- long_data |>

--- a/R/weo_bulk.R
+++ b/R/weo_bulk.R
@@ -178,6 +178,8 @@ create_weo_url <- function(year, release, country_groups = FALSE) {
       suffix,
       ".xls"
     )
+  } else if (year == 2011 && release == 2) {
+    paste0(base_url, "/", year, "/WEO", "Sep", year, suffix, ".ashx")
   } else {
     # Earlier format
     paste0(base_url, "/", year, "/WEO", month, year, suffix, ".xls")

--- a/R/weo_bulk.R
+++ b/R/weo_bulk.R
@@ -158,7 +158,7 @@ create_weo_url <- function(year, release, country_groups = FALSE) {
     paste0(base_url, "/", year, "/WEO", month, year, suffix, ".ashx")
   } else if (year == 2020 && release == 1) {
     # Special case: April 2020 uses .ashx
-    paste0(base_url, "/", year, "/WEO", month, year, suffix, ".ashx")
+    paste0(base_url, "/", year, "/WEO", month, year, suffix, ".xls")
   } else if (year >= 2020) {
     # Format from October 2020
     release_pad <- ifelse(
@@ -179,7 +179,7 @@ create_weo_url <- function(year, release, country_groups = FALSE) {
       ".xls"
     )
   } else if (year == 2011 && release == 2) {
-    paste0(base_url, "/", year, "/WEO", "Sep", year, suffix, ".ashx")
+    paste0(base_url, "/", year, "/WEO", "Sep", year, suffix, ".xls")
   } else {
     # Earlier format
     paste0(base_url, "/", year, "/WEO", month, year, suffix, ".xls")

--- a/tests/testthat/test-weo_bulk.R
+++ b/tests/testthat/test-weo_bulk.R
@@ -52,7 +52,7 @@ test_that("create_weo_url constructs correct URL for 2024+ format", {
   )
 })
 
-test_that("create_weo_url constructs correct URL for 2021–2023 format", {
+test_that("create_weo_url constructs correct URL for 2021-2023 format", {
   url <- create_weo_url(2021, 1)
   expect_match(url, "https://www.imf.org/.*/2021/WEOApr2021all.ashx")
 
@@ -63,6 +63,16 @@ test_that("create_weo_url constructs correct URL for 2021–2023 format", {
 test_that("create_weo_url constructs correct URL for 2020 format", {
   url <- create_weo_url(2020, 2)
   expect_match(url, "https://www.imf.org/.*/2020/02/WEOOct2020all.xls")
+})
+
+test_that("create_weo_url constructs correct URL for 2020 release 1 format", {
+  url <- create_weo_url(2020, 1)
+  expect_match(url, "https://www.imf.org/.*/2020/WEOApr2020all.ashx")
+})
+
+test_that("create_weo_url constructs correct URL for 2011 release 2 format", {
+  url <- create_weo_url(2011, 2)
+  expect_match(url, "https://www.imf.org/.*/2011/WEOSep2011all.ashx")
 })
 
 test_that("create_weo_url constructs correct URL for pre-2020 format", {

--- a/tests/testthat/test-weo_bulk.R
+++ b/tests/testthat/test-weo_bulk.R
@@ -67,12 +67,12 @@ test_that("create_weo_url constructs correct URL for 2020 format", {
 
 test_that("create_weo_url constructs correct URL for 2020 release 1 format", {
   url <- create_weo_url(2020, 1)
-  expect_match(url, "https://www.imf.org/.*/2020/WEOApr2020all.ashx")
+  expect_match(url, "https://www.imf.org/.*/2020/WEOApr2020all.xls")
 })
 
 test_that("create_weo_url constructs correct URL for 2011 release 2 format", {
   url <- create_weo_url(2011, 2)
-  expect_match(url, "https://www.imf.org/.*/2011/WEOSep2011all.ashx")
+  expect_match(url, "https://www.imf.org/.*/2011/WEOSep2011all.xls")
 })
 
 test_that("create_weo_url constructs correct URL for pre-2020 format", {


### PR DESCRIPTION
@t-emery since one of my students has to analyze the old WEO publications, we realized that a couple of them had download issues. My PR fixes these issues for all publications until 2025 Spring - I already verified it by downloading all old publications. Unfortunately, for publications after that, we need to use the IMFAPI - probably a good use case for the new `imfapi` package. I'll leave this part to @chriscarrollsmith.  